### PR TITLE
add HealthCheckGracePeriodSeconds to ECSService schema

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -2776,6 +2776,10 @@ type ECSService struct {
 	// Specify the tasks with the TaskDefinition property.
 	DesiredCount *IntegerExpr `json:"DesiredCount,omitempty"`
 
+	// The length of time in seconds after a new container comes into
+	// service before ECS starts checking its health.
+	HealthCheckGracePeriodSeconds *IntegerExpr `json:"HealthCheckGracePeriodSeconds,omitempty"`
+
 	// A list of load balancer objects to associate with the cluster. If you
 	// specify the Role property, LoadBalancers must be specified as well.
 	// For information about the number of load balancers that you can


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html#cfn-ecs-service-healthcheckgraceperiodseconds

I wasn't able to get the `scraper/auto.sh` script to run correctly, so this was added manually.


