### PR TITLE
add type to ALB

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -3517,6 +3517,9 @@ type ElasticLoadBalancingV2LoadBalancer struct {
 	// Specifies an arbitrary set of tags (key–value pairs) to associate
 	// with this load balancer. Use tags to manage your resources.
 	Tags []ResourceTag `json:"Tags,omitempty"`
+
+	// Type docs: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html#cfn-elasticloadbalancingv2-loadbalancer-type
+	Type *StringExpr `json:"Type,omitempty"`
 }
 
 // CfnResourceType returns AWS::ElasticLoadBalancingV2::LoadBalancer to implement the ResourceProperties interface


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html#cfn-elasticloadbalancingv2-loadbalancer-type

This value defaults to "application" for ALBs, but must be set to "network" for NLBs. I'm exploring NLBs here: https://github.com/Clever/catapult/pull/598